### PR TITLE
Added Mayhem support

### DIFF
--- a/.github/workflows/mayhem.yaml
+++ b/.github/workflows/mayhem.yaml
@@ -1,0 +1,58 @@
+name: Mayhem
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    name: '${{ matrix.os }} shared=${{ matrix.shared }} ${{ matrix.build_type }}'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        shared: [false]
+        build_type: [Release]
+        include:
+          - os: ubuntu-latest
+            triplet: x64-linux
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Start analysis
+        uses: ForAllSecure/mcode-action@v1
+        with:
+          mayhem-token: ${{ secrets.MAYHEM_TOKEN }}
+          args: --image ${{ steps.meta.outputs.tags }}
+          sarif-output: sarif
+
+      - name: Upload SARIF file(s)
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: sarif

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+## Use Rust to build
+FROM rustlang/rust:nightly as builder
+
+## Add source code to the build stage.
+ADD . /acpi
+WORKDIR /acpi
+
+RUN cargo install cargo-fuzz
+
+## TODO: ADD YOUR BUILD INSTRUCTIONS HERE.
+WORKDIR /acpi/aml/fuzz
+RUN cargo +nightly fuzz build fuzz_target_1
+# Output binary is placed in /acpi/aml/fuzz/target/x86_64-unknown-linux-gnu/release/fuzz_target_1
+
+# Package Stage
+FROM --platform=linux/amd64 ubuntu:20.04
+
+## Install build dependencies.
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y gcc
+
+## Copy the binary from the build stage to an Ubuntu docker image
+COPY --from=builder /acpi/aml/fuzz/target/x86_64-unknown-linux-gnu/release/fuzz_target_1 /fuzz-target-1

--- a/Mayhemfile
+++ b/Mayhemfile
@@ -1,0 +1,5 @@
+project: acpi
+target: acpi
+
+cmds:
+  - cmd: /fuzz-target-1

--- a/aml/fuzz/fuzz_targets/fuzz_target_1.rs
+++ b/aml/fuzz/fuzz_targets/fuzz_target_1.rs
@@ -11,7 +11,7 @@ fuzz_target!(|data: &[u8]| {
         simplelog::SimpleLogger::init(simplelog::LevelFilter::Trace, simplelog::Config::default()).unwrap();
     }
 
-    let mut context = aml::AmlContext::new(Box::new(Handler), false, aml::DebugVerbosity::None);
+    let mut context = aml::AmlContext::new(Box::new(Handler), aml::DebugVerbosity::None);
     let _ = context.parse_table(data);
 });
 


### PR DESCRIPTION
Added Mayhem support to the `acpi` project.

Integration was standard on this project, as some fuzzing binaries were already created by the maintainers of the project. A Dockerfile was added to compile the fuzzing binary, and a Mayhemfile and GitHub actions file were added to perform the Mayhem fuzzing tests.

One small change was added to the source code in `aml/fuzz/fuzz_targets/fuzz_target_1.rs`, the fuzzing file compiled to the binary. This file has not been updated in a while, and a call of a function was changed to use a new function signature. It is likely the project has not been fuzzed in some time.